### PR TITLE
Change isxdigit(key) -> all(isxdigit, key)

### DIFF
--- a/src/FredData.jl
+++ b/src/FredData.jl
@@ -73,7 +73,7 @@ function Fred()
     elseif length(key) < API_KEY_LENGTH
         error("Invalid FRED API key: ", key, ". Key too short.")
     end
-    if !isxdigit(key)
+    if !all(isxdigit, key)
         error("Invalid FRED API key: ", key, ". Invalid characters.")
     end
 


### PR DESCRIPTION
Small deprecation fix for Julia 0.6. (Hope you're doing well!)