### PR TITLE
warn -> @warn

### DIFF
--- a/src/FredData.jl
+++ b/src/FredData.jl
@@ -53,7 +53,7 @@ mutable struct Fred
         # Key validation
         if length(key) > API_KEY_LENGTH
             key = key[1:API_KEY_LENGTH]
-            warn("FRED API key too long. First $(API_KEY_LENGTH) chars used.")
+            @warn("FRED API key too long. First $(API_KEY_LENGTH) chars used.")
         elseif length(key) < API_KEY_LENGTH
             error("Invalid FRED API key -- key too short: $(key)")
         end

--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -74,7 +74,7 @@ function get_data(f::Fred, series::AbstractString; kwargs...)
             metadata_parsed[Symbol(k)] = metadata_json["seriess"][1][k]
         catch err
             metadata_parsed[Symbol(k)] = ""
-            warn("Metadata '$k' not returned from server.")
+            @warn("Metadata '$k' not returned from server.")
         end
     end
 
@@ -174,14 +174,14 @@ function validate_args!(kwargs)
         end
         vds_early = map(x -> x<EARLY_VINTAGE_DATE, vds_arr)
         if any(vds_early)
-            warn(:vintage_dates, ": Early vintage date, data might not exist: ",
+            @warn(:vintage_dates, ": Early vintage date, data might not exist: ",
                 vds_arr[vds_early])
         end
     end
     # all remaining keys have unspecified behavior
     if length(d) > 0
         for k in keys(d)
-            warn(string(k), ": Bad key. Removed from query.")
+            @warn(string(k), ": Bad key. Removed from query.")
             deleteat!(kwargs, findall(x -> x[1]==k, kwargs))
         end
     end


### PR DESCRIPTION
warn was deprecated a while ago.

In case want to test for these warnings (#12), this
```julia
s2 = get_data(f, "K1R53101ES000")
```
gives a warning because `Metadata 'notes' not returned from server.` 

