### PR TITLE
Future 0.7.0 Release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 DataFrames = "1.7.1"
 HTTP = "1.10.19"
 JSON = "1.0.1"
-StructUtils = "2.6.2"
+StructUtils = "2.3"
 TimeZones = "1.22.2"
 julia = "1.9"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,11 +12,11 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-DataFrames = "0.18, 0.19, 0.20, 0.21, 0.22, 1"
-HTTP = "0.8, 0.9, 1.2"
+DataFrames = "1.7.1"
+HTTP = "1.10.19"
 JSON = "0.18, 0.19, 0.20, 0.21"
-TimeZones = "0.11, 1"
-julia = "1"
+TimeZones = "1.22.2"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FredData"
 uuid = "6e85b7ee-7d24-5488-b1b7-e4f4198c51ac"
 author = ["Micah Smith <micahjsmith@gmail.com>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 [compat]
 DataFrames = "1.8"
 Dates = "1"
-HTTP = "1.10.19"
+HTTP = "1.10"
 JSON = "1.0.1"
 Printf = "1"
 StructUtils = "2.3"

--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,14 @@ StructUtils = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-DataFrames = "1.7.1"
+DataFrames = "1.8"
+Dates = "1"
 HTTP = "1.10.19"
 JSON = "1.0.1"
+Printf = "1"
 StructUtils = "2.3"
-TimeZones = "1.22.2"
-julia = "1.9"
+TimeZones = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+StructUtils = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 DataFrames = "1.7.1"
 HTTP = "1.10.19"
-JSON = "0.18, 0.19, 0.20, 0.21"
+JSON = "1.0.1"
+StructUtils = "2.6.2"
 TimeZones = "1.22.2"
 julia = "1.9"
 


### PR DESCRIPTION
@micahjsmith As discussed in https://github.com/micahjsmith/FredData.jl/pull/28, here's the base branch for a target 0.7.0 release. In the comment below, I have stacked PRs from my fork of this repo on top of this branch. I hope this makes the core review more manageable.

After briefly considering compatibility with Julia 1.9, I reverted back to the original plan of Julia 1.10 compatibility.

My code requires JSON 1.0+, which makes [typed materialization](https://juliaio.github.io/JSON.jl/stable/reading/#JSON.parse-Typed-materialization) available. Based on the `compat` for that package, StructUtils needs to be 2.3 or higher.

DataFrames 1.8 is the earliest version to require Julia 1.10, so I've chosen that as the lower bound&mdash;even though I suspect earlier versions may work. HTTP maintains a higher degree of backward compatibility, so I used a time heuristic to choose 1.10.

You should have received an invitation to be a collaborator on the forked repo. I can add you as a reviewer once that invitation has been accepted.